### PR TITLE
Set trusty as the default distro for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 
 compiler: g++


### PR DESCRIPTION
This closes https://github.com/wgma00/utscode/issues/1.